### PR TITLE
small style changes

### DIFF
--- a/_sass/_theme.scss
+++ b/_sass/_theme.scss
@@ -455,3 +455,14 @@ pre code {
     overflow-x: scroll;
   }
 }
+
+/*! MARK: custom changes from here until... */
+header div.container {
+  display: flex;
+  justify-content: right !important;
+
+  @include breakpoint(break-1) {
+      justify-content: center !important;
+  }
+}
+/*! MARK: ...here */

--- a/_sass/alembic.scss
+++ b/_sass/alembic.scss
@@ -9,3 +9,23 @@
   "flex",
   "theme"
 ;
+
+.article {
+  img {
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
+  }
+
+  thead {
+      display: none;
+  }
+
+  td {
+      padding: 1px;
+  }
+}
+
+.feature {
+  text-shadow: 0 0 1rem #000, 0 0 .5rem #000;
+}


### PR DESCRIPTION
- added background for white on white headings
- centered navbar
- aligned hamburger

looks shit with the default alebic pages but works with the [pirates-ophase.github.io](https://github.com/pirates-ophase/pirates-ophase.github.io) mess

I hope this works since jekyll is the spawn of the devil and I am just not intelligent enough to use ruby properly, I have copied the stylesheet changes from a different framework implementing the same website over to this jekyll theme. It _should_ work out of the box but I can't guarantee it as I could not test it

demo of changes: https://master.pirates-ophase-astro.pages.dev/

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="546" alt="Bildschirmfoto 2022-08-20 um 00 21 50" src="https://user-images.githubusercontent.com/22644818/185714567-0f86262e-369a-4c97-a749-feb5495493f2.png">
</td>
<td>
<img width="544" alt="Bildschirmfoto 2022-08-20 um 00 21 44" src="https://user-images.githubusercontent.com/22644818/185714595-b67a4744-a9d1-4e49-8029-b62f735bee67.png">
</td>
</tr>
<tr>
<td>
<img width="1500" alt="Bildschirmfoto 2022-08-20 um 00 19 52" src="https://user-images.githubusercontent.com/22644818/185714417-8427e349-f838-449f-802e-d7d69aafb46b.png">
</td>
<td>
<img width="1499" alt="Bildschirmfoto 2022-08-20 um 00 20 23" src="https://user-images.githubusercontent.com/22644818/185714441-25949f01-d3d6-4756-acf4-98e069a33b23.png">
</td>
</tr>
</tbody>
</tabe>
